### PR TITLE
Solucionado problema Derrota

### DIFF
--- a/XO Rivals/Assets/Scripts/Pistolero/Cronometro.cs
+++ b/XO Rivals/Assets/Scripts/Pistolero/Cronometro.cs
@@ -58,9 +58,18 @@ public class Cronometro : MonoBehaviour
         //SEPARAMOS SEGUNDOS Y DECIMAS DEL TIEMPO RESULTADO
         int segundos = (int)Math.Truncate(time);
         int decimas = (int)((time - segundos) * 100); //Sacamos dos decimas
+
         decimas = Math.Abs(decimas);//el signo negativo solo tiene que estar en los segundos
 
-        textoCrono.text = segundos + ":" + decimas;
+        if (time < 0 && time > -1) //el signo negativo lo ponemos nosotros debido a que en los segundos no está (en las decimas si)
+        {
+            textoCrono.text = "-"+segundos + ":" + decimas;
+        }
+        else
+        {
+            textoCrono.text = segundos + ":" + decimas;
+        }
+       
 
   //TiempoEnemigo
         int segundosEnemy = (int)Math.Truncate(timeEnemy);


### PR DESCRIPTION
En algunos casos el juego recibía derrota cuando el jugador podía ver como debería haber ganado, el problema era que no aparecía el signo negativo, por lo que perdía